### PR TITLE
Path resolution, transaction fixes, SQL store fixes

### DIFF
--- a/engines/node/lib/store-engine/sql.js
+++ b/engines/node/lib/store-engine/sql.js
@@ -32,7 +32,7 @@ function MysqlWrapper(params) {
 			cmd.on('row', function(r) {
 				results.rows.push(r);
 			});
-			cmd.on('end', function() {
+			cmd.on('result', function() {
 				if (conn.clean && callback) {
 					results.insertId = cmd.insert_id;
 					results.rowsAffected = cmd.affected_rows;

--- a/engines/node/lib/store-engine/sql.js
+++ b/engines/node/lib/store-engine/sql.js
@@ -26,7 +26,7 @@ function MysqlWrapper(params) {
 				errback(new DatabaseError("Cannot commit a transaction with an error"));
 				return;
 			}
-			var cmd = conn.query(query, args),
+			var cmd = conn.execute(query, args),
 				results = { rows: [] };
 
 			cmd.on('row', function(r) {

--- a/engines/node/lib/store-engine/sql.js
+++ b/engines/node/lib/store-engine/sql.js
@@ -56,11 +56,9 @@ function MysqlWrapper(params) {
             currentConnection = conn;
 			throwOnError(conn.query('SET autocommit=0;'), 'disable autocommit');
 			throwOnError(conn.query('BEGIN'), 'initialize transaction');
-            //console.log("start txn");
 
 			return {
 				commit: function() {
-                    //console.log("commit txn");
 					throwOnError(conn.query("COMMIT"), 'commit SQL transaction');
 					throwOnError(conn.close(), 'close connection');
 				},
@@ -69,11 +67,9 @@ function MysqlWrapper(params) {
 					throwOnError(conn.close(), 'close connection');
 				},
                 suspend: function(){
-                    //console.log("suspend");
                     currentConnection = null;
                 },
                 resume: function(){
-                    //console.log("resume");
                     currentConnection = conn;
                 }
 			};
@@ -88,7 +84,6 @@ function MysqlWrapper(params) {
 	}
 
 	function connectMysql(params) {
-        //console.log("connecting to mysql");
 		var ret = require("mysql-native/client").createTCPClient(params.host, params.port);
 		ret.auto_prepare = true;
 		ret.row_as_hash = true;

--- a/lib/path.js
+++ b/lib/path.js
@@ -81,7 +81,7 @@ function getFromDataModel(dataModel, path){
 			require("sys").puts("get from " + model + " path: " + path);
 	
     if(model._linkResolving){
-        model.get(path);
+        return model.get(path);
     }else{
         return exports.resolver(model, function(){;
             return dataModel;

--- a/lib/path.js
+++ b/lib/path.js
@@ -14,7 +14,7 @@ exports.resolver = function resolver(model, getDataModel){
     
     var originalGet = model.get;
     
-	return function(id, metadata){
+    return function(id, metadata){
         var self = this;
         metadata = metadata || {};
         id = '' + id;
@@ -80,9 +80,13 @@ function getFromDataModel(dataModel, path){
 	}while(proceed);
 			require("sys").puts("get from " + model + " path: " + path);
 	
-	return exports.resolver(model, function(){;
-		return dataModel;
-	}).call(model, path);
+    if(model._linkResolving){
+        model.get(path);
+    }else{
+        return exports.resolver(model, function(){;
+            return dataModel;
+        }).call(model, path);
+    }
 }	
 
 exports.LinkResolving = function(model, getDataModel){
@@ -92,6 +96,7 @@ exports.LinkResolving = function(model, getDataModel){
 //    getDataModel: Optional parameter for resolving cross-model references
 
     model.links = model.links || [];
+    model._linkResolving = true;
 
     var resolvingGet = exports.resolver(model, getDataModel);
     

--- a/lib/path.js
+++ b/lib/path.js
@@ -93,6 +93,9 @@ exports.LinkResolving = function(model, getDataModel){
 //    model: the model object to wrap
 //    getDataModel: Optional parameter for resolving cross-model references
 
+    //the resolver expects there to be a links array
+    model.links = model.links || [];
+
     var originalGet = model.get;
 
     var resolvingGet = function(id, metadata){

--- a/lib/path.js
+++ b/lib/path.js
@@ -194,7 +194,7 @@ exports.LinkResolving = function(model, getDataModel){
 
     var originalPut = model.put;
     
-    model.put = function(obj){
+    model.put = function(obj, directives){
         var putObj = obj;
         var links = model.links.filter(function(link){
             return link.resolution !== undefined && (link.resolution == "eager" || link.resolution == "lazy");
@@ -212,7 +212,7 @@ exports.LinkResolving = function(model, getDataModel){
                 delete putObj[link.rel];
             });
         }
-        originalPut.call(this, putObj);
+        originalPut.call(this, putObj, directives);
     }
 
     return model;

--- a/lib/path.js
+++ b/lib/path.js
@@ -22,7 +22,6 @@ exports.resolver = function resolver(model, getDataModel){
         var schema = this;
         if(id.indexOf('/') > -1 && (id.indexOf('?') == -1 || id.indexOf('/') < id.indexOf('?'))){
             var parts = id.split('/');
-            if(parts[0]=="undefined") throw new Error();
             var value = originalGet.call(this, parts.shift());
             parts.forEach(function(part){
                 value = when(value, function(value){

--- a/lib/path.js
+++ b/lib/path.js
@@ -86,3 +86,131 @@ function getFromDataModel(dataModel, path){
 		return dataModel;
 	})(path);
 }	
+
+exports.LinkResolving = function(model, getDataModel){
+//Model wrapper that uses schema links to incorporate
+//sub-objects or references into the object
+//    model: the model object to wrap
+//    getDataModel: Optional parameter for resolving cross-model references
+
+    var originalGet = model.get;
+
+    var resolvingGet = function(id, metadata){
+        var self = this;
+        metadata = metadata || {};
+        id = '' + id;
+        var schema = this;
+        if(id.indexOf('/') > -1 && (id.indexOf('?') == -1 || id.indexOf('/') < id.indexOf('?'))){
+            var parts = id.split('/');
+            var value = originalGet.call(this, parts.shift());
+            parts.forEach(function(part){
+                value = when(value, function(value){
+                    var linkTarget =  getLink(part, value, schema);
+
+                    if(!linkTarget){
+                        value = value && value[part];
+                        linkTarget = value && value.$ref;
+                    }
+                    if(linkTarget){
+                        if((linkTarget.charAt(0) == '/' || linkTarget.substring(0,3) == '../') && getDataModel){
+                            value = getFromDataModel(getDataModel(), linkTarget.substring(linkTarget.charAt(0) == '/' ? 1 : 3));
+                        }else{
+                            value = originalGet.call(self, linkTarget);
+                        }
+                    }
+                    return value;
+                }); 
+            });
+            return value;
+        }
+        if(id === '' || id.charAt(0) == "?"){
+            return model.query(id.substring(1), metadata);
+        }
+        if(id.match(/^\(.*\)$/)){
+            // handle paranthesis embedded, comma separated ids
+            if(id.length == 2){ // empty array
+                return [];
+            }
+            var parts = id.substring(1, id.length -1).split(',');
+            return all(parts.map(function(part){
+                return originalGet.call(self, part, metadata);
+            }));
+        }
+        return originalGet.call(this, id, metadata);
+    };
+    
+    var resolve = function(obj,metadata){
+        var self = this;
+        var promises = model.links.filter(function(link){
+            return link.resolution !== undefined && (link.resolution == "eager" || link.resolution == "lazy");
+        }).map(function(link){
+            if(link.resolution == "eager"){
+                //put the resolved sub-object into the object
+                var id = (model.getId) ? model.getId(obj) : obj.id;
+                return when(resolvingGet.call(self, id + "/" + link.rel, metadata), function(subObject){
+                    obj[link.rel] = subObject;
+                });
+            }else if(link.resolution == "lazy"){
+                //put a reference to the sub-object into the object
+                var addLinkTask = new Promise();
+                obj[link.rel] = {"$ref": getLink(link.rel, obj, model)};
+                addLinkTask.callback();
+                return addLinkTask;
+            }
+        });
+        return when(all(promises), function(){return obj;});
+    }
+    
+    
+    model.get = function(id, metadata){
+        var self = this;
+        var rawResult = resolvingGet.call(this, id, metadata);
+        if(id.indexOf("/")<0){
+            return when(rawResult,function(rawResult){
+                return resolve.call(self, rawResult, metadata);
+            });
+        }
+        return rawResult;
+    };
+    
+    var originalQuery = model.query;
+    
+    model.query = function(query, metadata){
+        var self = this;
+        var rawResult = originalQuery.call(this, query, metadata);
+        if(model.links.some(function(link){ return link.resolution!==undefined; })){
+            return when(rawResult, function(rawResult){
+                var promises = rawResult.map(function(obj){
+                    return resolve.call(self, obj, metadata);
+                });
+                return when(all(promises), function(){ return rawResult; });
+            });
+        }
+        return rawResult;
+    }
+
+    var originalPut = model.put;
+    
+    model.put = function(obj){
+        var putObj = obj;
+        var links = model.links.filter(function(link){
+            return link.resolution !== undefined && (link.resolution == "eager" || link.resolution == "lazy");
+        });
+        if(links.length >0){
+            putObj = {};
+            //clone the object
+            for(key in obj){
+                if(obj.hasOwnProperty(key)){
+                    putObj[key] = obj[key];
+                }
+            }
+            //remove the objects that were added by links
+            links.forEach(function(link){
+                delete putObj[link.rel];
+            });
+        }
+        originalPut.call(this, putObj);
+    }
+
+    return model;
+}

--- a/lib/path.js
+++ b/lib/path.js
@@ -4,23 +4,25 @@
 var all = require("promised-io/promise").all,
 	when = require("promised-io/promise").when,
     Promise = require("promised-io/promise").Promise,
+    LazyArray = require("promised-io/lazy-array").LazyArray,
 	getLink = require("commonjs-utils/json-schema").getLink;
 
 exports.resolver = function resolver(model, getDataModel){
-	// Creates a function for resolving ids that have dot-delimited paths,
+	// Creates a function for resolving ids that have slash-delimited paths,
 	// and resolves any links in those paths
 	// 		store: The name of the store to use to resolve ids
 	//		getDataModel: Optional parameter for resolving cross-model references 
     
     var originalGet = model.get;
     
-    return function(id, metadata){
+	return function(id, metadata){
         var self = this;
         metadata = metadata || {};
         id = '' + id;
         var schema = this;
         if(id.indexOf('/') > -1 && (id.indexOf('?') == -1 || id.indexOf('/') < id.indexOf('?'))){
             var parts = id.split('/');
+            if(parts[0]=="undefined") throw new Error();
             var value = originalGet.call(this, parts.shift());
             parts.forEach(function(part){
                 value = when(value, function(value){
@@ -108,9 +110,15 @@ exports.LinkResolving = function(model, getDataModel){
             if(link.resolution == "eager"){
                 //put the resolved sub-object into the object
                 var id = (model.getId) ? model.getId(obj) : obj.id;
-                return when(resolvingGet.call(self, id + "/" + link.rel, metadata), function(subObject){
-                    obj[link.rel] = subObject;
+                var promise = when(resolvingGet.call(self, id + "/" + link.rel, metadata), function(subObject){
+                    if(subObject instanceof LazyArray){
+                        //unpack the lazy array
+                        promise = when(subObject.toRealArray(), function(arr){ obj[link.rel]=arr; });
+                    }else{
+                        obj[link.rel] = subObject;
+                    }
                 });
+                return promise;
             }else if(link.resolution == "lazy"){
                 //put a reference to the sub-object into the object
                 var addLinkTask = new Promise();
@@ -126,7 +134,7 @@ exports.LinkResolving = function(model, getDataModel){
     model.get = function(id, metadata){
         var self = this;
         var rawResult = resolvingGet.call(this, id, metadata);
-        if(id.indexOf("/")<0){
+        if(id.indexOf("/")<0 && id.indexOf("?")<0){
             return when(rawResult,function(rawResult){
                 return resolve.call(self, rawResult, metadata);
             });

--- a/lib/path.js
+++ b/lib/path.js
@@ -25,20 +25,7 @@ exports.resolver = function resolver(model, getDataModel){
             var value = originalGet.call(this, parts.shift());
             parts.forEach(function(part){
                 value = when(value, function(value){
-                    var linkTarget =  getLink(part, value, schema);
-
-                    if(!linkTarget){
-                        value = value && value[part];
-                        linkTarget = value && value.$ref;
-                    }
-                    if(linkTarget){
-                        if((linkTarget.charAt(0) == '/' || linkTarget.substring(0,3) == '../') && getDataModel){
-                            value = getFromDataModel(getDataModel(), linkTarget.substring(linkTarget.charAt(0) == '/' ? 1 : 3));
-                        }else{
-                            value = originalGet.call(self, linkTarget);
-                        }
-                    }
-                    return value;
+                    return resolveLink(schema, value, part, originalGet, getDataModel);
                 }); 
             });
             return value;
@@ -64,6 +51,27 @@ exports.resolve = function(id, metadata, store, dataModel){
 	return resolver(store, dataModel)(id, metadata);
 }
 
+function resolveLink(model, obj, linkId, getFunction, getDataModel){
+    var id = (model.getId) ? model.getId(obj) : obj.id;
+    id = ""+id;
+    //console.log("resolving " + id + "/" + linkId);
+    var value = obj;
+    var linkTarget =  getLink(linkId, value, model);
+    if(!linkTarget){
+        value = value && value[linkId];
+        linkTarget = (value!==undefined) && value.$ref;
+    }
+    if(linkTarget){
+        if((linkTarget.charAt(0) == '/' || linkTarget.substring(0,3) == '../') && getDataModel){
+            value = getFromDataModel(getDataModel(), linkTarget.substring(linkTarget.charAt(0) == '/' ? 1 : 3));
+        }else{
+            value = getFunction.call(self, linkTarget);
+        }
+    }
+    return value;
+    
+}
+
 function getFromDataModel(dataModel, path){
 	var model = dataModel;
 	var part; 
@@ -79,7 +87,7 @@ function getFromDataModel(dataModel, path){
 			}
 		}
 	}while(proceed);
-			require("sys").puts("get from " + model + " path: " + path);
+			require("sys").puts("get from " + model.instanceSchema.id + " path: " + path);
 	
     if(model._linkResolving){
         return model.get(path);
@@ -99,6 +107,7 @@ exports.LinkResolving = function(model, getDataModel){
     model.links = model.links || [];
     model._linkResolving = true;
 
+    var originalGet = model.get;
     var resolvingGet = exports.resolver(model, getDataModel);
     
     var resolve = function(obj,metadata){
@@ -109,10 +118,11 @@ exports.LinkResolving = function(model, getDataModel){
             if(link.resolution == "eager"){
                 //put the resolved sub-object into the object
                 var id = (model.getId) ? model.getId(obj) : obj.id;
-                var promise = when(resolvingGet.call(self, id + "/" + link.rel, metadata), function(subObject){
+                var value =  resolveLink(model, obj, link.rel, originalGet, getDataModel);
+                var promise = when(value, function(subObject){
                     if(subObject instanceof LazyArray){
                         //unpack the lazy array
-                        promise = when(subObject.toRealArray(), function(arr){ obj[link.rel]=arr; });
+                        promise = when(subObject.toRealArray(), function(arr){ obj[link.rel]=arr;});
                     }else{
                         obj[link.rel] = subObject;
                     }
@@ -131,6 +141,7 @@ exports.LinkResolving = function(model, getDataModel){
     
     
     model.get = function(id, metadata){
+        id=""+id;
         var self = this;
         var rawResult = resolvingGet.call(this, id, metadata);
         if(id.indexOf("/")<0 && id.indexOf("?")<0){

--- a/lib/path.js
+++ b/lib/path.js
@@ -3,102 +3,18 @@
  */
 var all = require("promised-io/promise").all,
 	when = require("promised-io/promise").when,
+    Promise = require("promised-io/promise").Promise,
 	getLink = require("commonjs-utils/json-schema").getLink;
 
-exports.resolver = function resolver(store, getDataModel){
+exports.resolver = function resolver(model, getDataModel){
 	// Creates a function for resolving ids that have dot-delimited paths,
 	// and resolves any links in those paths
 	// 		store: The name of the store to use to resolve ids
 	//		getDataModel: Optional parameter for resolving cross-model references 
-	return function(id, metadata){
-		metadata = metadata || {};
-		id = '' + id;
-		var schema = this;
-		if(id.indexOf('.') > -1 && (id.indexOf('?') == -1 || id.indexOf('.') < id.indexOf('?'))){
-			var parts = id.split('.');
-			var value = store.get(parts.shift());
-			parts.forEach(function(part){
-				value = when(value, function(value){
-					var linkTarget = schema != this && getLink(part, value, schema);
-					if(!linkTarget){
-						value = value && value[part];
-						linkTarget = value && value.$ref;
-					}
-					if(linkTarget){
-						if((linkTarget.charAt(0) == '/' || linkTarget.substring(0,3) == '../') && getDataModel){
-							value = getFromDataModel(getDataModel(), linkTarget.substring(linkTarget.charAt(0) == '/' ? 1 : 3));
-						}else{
-							value = store.get(linkTarget);
-						}
-					}
-					return value;
-				}); 
-			});
-			return value;
-		}
-		if(id === '' || id.charAt(0) == "?"){
-			return store.query(id.substring(1), metadata);
-		}
-		var parts = id.match(/[\.#][^\.#]+/g);
-		if(parts){
-			var value = store.get(id.match(/^([^\.#]*)[\.#]/)[0]);
-			for(var i = 0; i < parts.length; i++){
-				var part = parts[i];
-				value = value[part.substring(1)];
-			}
-			return value;
-		}
-		if(id.match(/^\(.*\)$/)){
-			// handle paranthesis embedded, comma separated ids
-			if(id.length == 2){ // empty array
-				return [];
-			}
-			var parts = id.substring(1, id.length -1).split(',');
-			return all(parts.map(function(part){
-				return store.get(part, metadata);
-			}));
-		}
-		return store.get(id, metadata);
-	};
-};
-exports.resolve = function(id, metadata, store, dataModel){
-	return resolver(store, dataModel)(id, metadata);
-}
-
-function getFromDataModel(dataModel, path){
-	var model = dataModel;
-	var part; 
-	do{
-		var proceed = false;
-		var slashIndex = path.indexOf("/");
-		if(slashIndex > -1){
-			part = path.substring(0, slashIndex);
-			if(model[part]){
-				model = model[part];
-				path = path.substring(slashIndex + 1);
-				proceed = true;
-			}
-		}
-	}while(proceed);
-			require("sys").puts("get from " + model + " path: " + path);
-	
-	return exports.resolver(model, function(){;
-		return dataModel;
-	})(path);
-}	
-
-exports.LinkResolving = function(model, getDataModel){
-//Model wrapper that uses schema links to incorporate
-//sub-objects or references into the object
-//    model: the model object to wrap
-//    getDataModel: Optional parameter for resolving cross-model references
-
-    //the resolver expects there to be a links array
-    model.links = model.links || [];
-
+    
     var originalGet = model.get;
-
-    var resolvingGet = function(id, metadata){
+    
+	return function(id, metadata){
         var self = this;
         metadata = metadata || {};
         id = '' + id;
@@ -141,6 +57,43 @@ exports.LinkResolving = function(model, getDataModel){
         }
         return originalGet.call(this, id, metadata);
     };
+};
+
+exports.resolve = function(id, metadata, store, dataModel){
+	return resolver(store, dataModel)(id, metadata);
+}
+
+function getFromDataModel(dataModel, path){
+	var model = dataModel;
+	var part; 
+	do{
+		var proceed = false;
+		var slashIndex = path.indexOf("/");
+		if(slashIndex > -1){
+			part = path.substring(0, slashIndex);
+			if(model[part]){
+				model = model[part];
+				path = path.substring(slashIndex + 1);
+				proceed = true;
+			}
+		}
+	}while(proceed);
+			require("sys").puts("get from " + model + " path: " + path);
+	
+	return exports.resolver(model, function(){;
+		return dataModel;
+	}).call(model, path);
+}	
+
+exports.LinkResolving = function(model, getDataModel){
+//Model wrapper that uses schema links to incorporate
+//sub-objects or references into the object
+//    model: the model object to wrap
+//    getDataModel: Optional parameter for resolving cross-model references
+
+    model.links = model.links || [];
+
+    var resolvingGet = exports.resolver(model, getDataModel);
     
     var resolve = function(obj,metadata){
         var self = this;
@@ -214,6 +167,6 @@ exports.LinkResolving = function(model, getDataModel){
         }
         originalPut.call(this, putObj, directives);
     }
-
+    
     return model;
 }

--- a/lib/store/sql.js
+++ b/lib/store/sql.js
@@ -14,6 +14,11 @@ var first = require("promised-io/lazy-array").first,
 	sqlOperators = require("rql/parser").commonOperatorMap;
 
 var valueToSql = exports.valueToSql = function(value){
+    if(value instanceof Array){
+        return "(" + value.map(function(element){
+            return valueToSql(element);
+        }).join(",") + ")";
+    }
 	return typeof(value) == "string" ? "'" + value.replace(/'/g,"''") + "'" : value + '';
 }; 
 
@@ -120,6 +125,7 @@ exports.SQLStore = function(config){
 									safeSqlName(column);
 									addClause(column + " IN " + valueToSql(term.args[1]));
 								}
+                                break;
 							}
 							// else fall through 
 						case "ne": case "lt": case "le": case "gt": case "ge":

--- a/lib/store/sql.js
+++ b/lib/store/sql.js
@@ -39,7 +39,7 @@ exports.SQLStore = function(config){
 	var store = { 
 		selectColumns: ["*"],
 		get: function(id){
-			return when(store.executeSql("SELECT * FROM " + config.table + " WHERE " + idColumn + "=?", [id]), function(result){
+			return when(store.executeSql("SELECT " + store.selectColumns.join(",") + " FROM " + config.table + " WHERE " + idColumn + "=?", [id]), function(result){
 				return first(result.rows);
 			});
 		},

--- a/lib/store/sql.js
+++ b/lib/store/sql.js
@@ -288,7 +288,10 @@ exports.SQLStore = function(config){
 			print(sql);
 			//print( first(this.executeSql(sql).rows) );
 			
-		}
+		},
+        transaction: function(){
+            return database.transaction();
+        }
 	};
 	var dialect = exports.dialects[config.type];
 	for(var i in dialect){
@@ -316,7 +319,6 @@ exports.openDatabase = function(parameters){
 	}
 
 	var db = SQLDatabase(parameters);
-	require("../transaction").registerDatabase(db);
 	return db;
 };
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -29,14 +29,15 @@ exports.registerDatabase = function(database){
 	database.id = nextDatabaseId++; 
 };
 
-var transactions = {};
-
-
 exports.transaction = function(callback){
+
+    var transactions = {};
+
 	var context = promiseModule.currentContext;
 	if(!context){
 		context = promiseModule.currentContext = {};
 	}
+    
 	context.suspend = function(){
 		try{
 			for(var i in transactions){
@@ -54,6 +55,7 @@ exports.transaction = function(callback){
 			exports.currentTransaction = null;
 		}
 	};
+    
 	context.resume = function(){
 		exports.currentTransaction = transaction; 
 		for(var i in transactions){
@@ -67,11 +69,12 @@ exports.transaction = function(callback){
 			}
 		}
 	};
-
-	var throwing = true, committing;
+    
+	var throwing = true;
 	function done(){
 		delete context.resume;
 		delete context.suspend;
+        exports.currentTransaction = null;
 	}
 	
 	var database = defaultDatabase;
@@ -91,7 +94,7 @@ exports.transaction = function(callback){
 					}
 					for(var i in usedStores){
 						if(usedStores[i].prepareCommit){
-							transactions[i].prepareCommit();
+							usedStores[i].prepareCommit();
 						}
 					}
 					for(var i in transactions){
@@ -103,11 +106,12 @@ exports.transaction = function(callback){
 						}
 					}
 					var success = true;
-					exports.currentTransaction = null;
 				}finally{
 					if(!success){
 						this.abort();
-					}
+					}else{
+                        done();
+                    }
 				}				
 			},
 			abort: function(){
@@ -122,36 +126,22 @@ exports.transaction = function(callback){
 					}
 				}
 				finally{
-					exports.currentTransaction = null;
+					done();
 				}
 			},
 		});
 		throwing = false;
 		return when(result, function(result){
-			committing = true;
-			done();
 			transaction.commit();
-			exports.currentTransaction = null;
 			return result;
 		}, function(e){
-			committing = true;
-			done();
 			transaction.abort();
-			exports.currentTransaction = null;
 			return result;
 		});
 	}
 	finally{
 		if(throwing){
-			done();
 			transaction.abort();
-			exports.currentTransaction = null;
-		}
-		else{
-			if(!committing){
-				context.suspend();
-				exports.currentTransaction = null;
-			}
 		}
 	}
 	
@@ -160,32 +150,9 @@ var nextStoreId = 0;
 
 exports.AutoTransaction = function(store, database){
 	database = database || defaultDatabase;
-	for(var i in store){
-		if(typeof store[i] === "function" && i != "transaction" && i != "setSchema"){
-			(function(i, defaultMethod){
-				store[i] = function(){
-					if(!exports.currentTransaction){
-						var args = arguments;
-						return exports.transaction(function(){
-							return startAndCall(args);
-						});
-					}
-					return startAndCall(arguments);
-				};
-				function startAndCall(args){
-					if(!store.id){
-						store.id = "__auto__" + (nextStoreId++);
-					}
-					if(!exports.currentTransaction.usedStores[store.id] && store.transaction){
-						exports.currentTransaction.usedStores[store.id] = store.transaction();
-					}
-					return defaultMethod.apply(store, args);
-				}
-			})(i, store[i]);
-		}
-	}
-	var transactionQueue;
-	var prototype = {
+    
+    //setup the store if it isn't already
+    var prototype = {
 		transaction: function(){
 			var queue = transactionQueue = [];
 			return {
@@ -218,5 +185,33 @@ exports.AutoTransaction = function(store, database){
 			store[i] = prototype[i];
 		}
 	}
+    
+    //issue the call in a transaction if appropriate
+	for(var i in store){
+		if(typeof store[i] === "function" && i != "setSchema" && i != "setPath" && !prototype.hasOwnProperty(i)){
+			(function(i, defaultMethod){
+				store[i] = function(){
+					if(!exports.currentTransaction){
+						var args = arguments;
+						return exports.transaction(function(){
+							return startAndCall(args);
+						});
+					}
+					return startAndCall(arguments);
+				};
+				function startAndCall(args){
+					if(!store.id){
+						store.id = "__auto__" + (nextStoreId++);
+					}
+					if(!exports.currentTransaction.usedStores[store.id] && store.transaction){
+						exports.currentTransaction.usedStores[store.id] = store.transaction();
+					}
+					return defaultMethod.apply(store, args);
+				}
+			})(i, store[i]);
+		}
+	}
+	var transactionQueue;
+	
 	return store;
 }


### PR DESCRIPTION
There are three interrelated sets of fixes here.

The first is path resolution for JSONSchema links.  As we discussed, this requires a change to the JSONSchema specification, adding a "resolution" element to links.  If present, the resolution can be specified as "eager" or "lazy".

This block of changes includes a "LinkResolving" model wrapper that uses the new JSONSchema properties to automatically include additional sub-objects for "eager" links, and references to sub objects for "lazy" links.  Links with other or non-existent resolutions are ignored.

One additional note about these changes is that the new link resolver does not use the "." notation for sub-objects that was used by Persevere 1.0 and by portions of this code previously.  Instead, sub-objects are delimited by "/".  I have been advised that this is considered the correct behavior in Persevere 2.0.

This block of changes also includes fixes to the Transaction framework to fix issues that could arise if an underlying store returns a deferred result which could lead to multiple changes and commits being issued on the wrong transaction if multiple requests come in at around the same time.  As part of these changes, some of the transaction code was cleaned up a bit, and the AutoTransaction wrapper was modified to not wrap a few extra functions that should not be transactional.  Note that in order to function correctly in Persevere, these changes depend on changes to the context wrapper jsgi app in Pintura which have been contributed in a separate pull request.  In order to function correctly outside of Persevere, these changes probably depend on changes to context suspension and resumption that were contributed to promised-io in a separate pull request.

Finally, these changes include some fixes to the MySQL store, as well as some optimization of MySQL connections.  Because MySQL does not support suspending and resuming transactions, it is important that every MySQL transaction have its own connection.  The transaction fixes described above are now used to make sure that the SqlStore's current connection is always correct for the current transaction.  In addition, SqlStore no longer registers itself as a database, instead it follows the usedStore pattern, which results in significantly fewer open connections and unnecessary commits when you have a large number of MySQL based stores.
