### PR TITLE
pass along directives to add when calling via post

### DIFF
--- a/facet.js
+++ b/facet.js
@@ -273,7 +273,7 @@ function FacetedStore(store, facetSchema){
 		}
 		if(!directives.id){
 			// create a new object
-			return this.add(props);
+			return this.add(props, directives);
 		}
 		else{
 			// check to see if it is an RPC object


### PR DESCRIPTION
this commit makes it so that `model.put` gets the directives when it is called as a result of a post.
