### PR TITLE
update mongodb store to return the id after `put`

### DIFF
--- a/store/mongodb.js
+++ b/store/mongodb.js
@@ -275,7 +275,7 @@ module.exports = function(options){
 							// .insert() returns array, we need the first element
 							obj = obj && obj[0];
 							if (obj) delete obj._id;
-							deferred.resolve(obj);
+							deferred.resolve(obj.id);
 						});
 					} else {
 						deferred.reject(id + " exists, and can't be overwritten");
@@ -285,7 +285,7 @@ module.exports = function(options){
 				collection.update(search, object, {upsert: directives.overwrite}, function(err, obj){
 					if (err) return deferred.reject(err);
 					if (obj) delete obj._id;
-					deferred.resolve(obj);
+					deferred.resolve(id);
 				});
 			}
 			return deferred;


### PR DESCRIPTION
the mongodb store is returning the object after doing a `put`.  this changes it to return the `id` so that it is consistent with the API for stores.
