### PR TITLE
Fixing ordering of Peristent store init

### DIFF
--- a/store/memory.js
+++ b/store/memory.js
@@ -197,11 +197,11 @@ var JSONExt = require("../util/json-ext"),
 
 var Persistent = exports.Persistent = function(options) {
 	options = options || {};
-	var path = options.path || require("../util/settings").dataFolder || "data";
+	var path = options.path || require("../util/settings").dataFolder || "data",
+		store = Memory(options);
 	if(options.filename){
 		initializeFile(options.filename);
 	}
-	var store = Memory(options);
 	function initializeFile(filename){
 		if(!filename){
 			throw new Error("A path/filename must be provided to the store");


### PR DESCRIPTION
There appears to be an issue when using Persistent store where if you pass a `filename` in the options, it will call `initializeFile(filename)` prior to creating the memory store.  This is fine when the store does not exist, but when it does exist the store is not then available when `store.setIndex()` is called in `initializeFile()`.

This pull request resolves that by creating the memory store prior to any point where the `initializeFile()` is called.
