### PR TITLE
fix #44

### DIFF
--- a/util/settings.js
+++ b/util/settings.js
@@ -9,7 +9,9 @@ if(!read){
 	read = require("file").read;
 }
 try{
-	var settings = JSON.parse(read("local.json").toString("utf8"));
+	var settings;
+	if (typeof java == "object") JSON.parse(getResource("local.json").content);
+	else JSON.parse(read("local.json").toString("utf8"));
 	for(var i in settings){
 		exports[i] = settings[i];
 	}


### PR DESCRIPTION
Use getResource("local.json") instead of read("local.json") when running under RingoJS
