### PR TITLE
check for id in instance for conflict detection

### DIFF
--- a/facet.js
+++ b/facet.js
@@ -210,12 +210,12 @@ function FacetedStore(store, facetSchema){
 			directives.id = facetSchema.getId(props);
 		}
 		if(typeof props.save !== "function"){
-			try{
-				if(needsOldVersion){
+			if(directives.id && needsOldVersion){
+				try{
 					instance = this.get(directives.id);
 				}
-			}
-			catch(e){
+				catch(e){
+				}
 			}
 			var self = this;
 			return when(instance, function(instance){


### PR DESCRIPTION
Just check if there is a directives.id, otherwise the error will prevent saving if there are links to be resolved. The resolving get needs an id.
