### PR TITLE
make it possible to distinguish update and add notifications.

### DIFF
--- a/store/notifying.js
+++ b/store/notifying.js
@@ -25,20 +25,20 @@ exports.Notifying = function(store, options){
 		if(directives && directives['client-id']){
 			clientHub = hub.fromClient(directives['client-id']);
 		}
-		return clientHub.subscribe(path, /*directives.body || */["put", "delete"]);
+		return clientHub.subscribe(path, /*directives.body || */["add", "put", "delete"]);
 	};
 	store.unsubscribe = function(path, directives){
 		var clientHub = hub;
 		if(directives && directives['client-id']){
 			clientHub = hub.fromClient(directives['client-id']);
 		}
-		return clientHub.unsubscribe(path, ["put", "delete"]);
+		return clientHub.unsubscribe(path, ["add", "put", "delete"]);
 	};
 	var originalPut = store.put;
 	if(originalPut){
 		store.put= function(object, directives){
 			if(options && options.revisionProperty){
-				object[options.revisionProperty] = (object[options.revisionProperty] || 0) + 1; 
+				object[options.revisionProperty] = (object[options.revisionProperty] || 0) + 1;
 			}
 			var result = originalPut(object, directives) || object.id;
 			if(directives && directives.replicated){
@@ -48,7 +48,7 @@ exports.Notifying = function(store, options){
 				localHub.publish({
 					channel: id,
 					result: object,
-					type: "put"
+					type: directives && directives.overwrite === false ? "add" : "put"
 				});
 				return id;
 			});
@@ -60,12 +60,12 @@ exports.Notifying = function(store, options){
 			var result = originalAdd(object, directives) || object.id;
 			if(directives && directives.replicated){
 				return result;
-			}		
+			}
 			return when(result, function(id){
 				localHub.publish({
 					channel: id,
 					result: object,
-					type: "put"
+					type: "add"
 				});
 				return id;
 			});


### PR DESCRIPTION
when subscribing to perstore, all notifications are either `'update'` or `'delete'`.  i'm using dstore as a client and it handles `'add'` differently to `'update'`.  it's not possible to infer whether or not an `'update'` from perstore is really an `'update'` or an `'add'`.  it would be good to introduce an explicit `'add'` topic or at least make it possible to infer an `'add'` from an `'update'` topic.
