### PR TITLE
clear isNew any time save completes

### DIFF
--- a/facet.js
+++ b/facet.js
@@ -419,7 +419,6 @@ var SchemaControlled = function(facetSchema, sourceClass, permissive){
 								mustBeValid(validation);
 								var isNew = partial === NEW;
 								if(isNew && (typeof facetSchema.add === "function")){ //  || )
-									partial = undefined;
 									id = facetSchema.add(source, directives);
 								}
 								else if(typeof facetSchema.put === "function"){
@@ -446,6 +445,7 @@ var SchemaControlled = function(facetSchema, sourceClass, permissive){
 								}*/
 								return when(id, function(id){
 									if(isNew){
+										partial = undefined;
 										if((typeof id == "string" || typeof id == "number") && promiseModule.currentContext){
 											promiseModule.currentContext.generatedId = id;
 										}


### PR DESCRIPTION
if the first `save` was new, calling `save` multiple times was identifying each one as being new unless the schema had an `add` method.  this sets things up so that the `isNew` flag will only be set for
the first call to `save` and any following calls will be treated like an update.
