### PR TITLE
assign allowedOperators to constructor

### DIFF
--- a/facet.js
+++ b/facet.js
@@ -98,7 +98,7 @@ function FacetedStore(store, facetSchema){
 		return this.wrap(facetSchema.query(query, directives), this.transaction);
 	};
 
-	var allowedOperators = constructor.allowedOperators || store.allowedOperators
+	var allowedOperators = constructor.allowedOperators = store.allowedOperators
 		|| {
 			select: true,
 			limit: true, // required

--- a/facet.js
+++ b/facet.js
@@ -111,7 +111,7 @@ function FacetedStore(store, facetSchema){
 			gt: "indexed",
 			sort: "indexed"
 		};
-	var maxLimit = constructor.maxLimit || store.maxLimit || 50;
+	var maxLimit = constructor.maxLimit = store.maxLimit || 50;
 
 	constructor.checkQuery = function(query){
 		var lastLimit;


### PR DESCRIPTION
for some reason, the code was reading from `constructor.allowedOperators` which was always going to be nothing but i was having issues with getting `allowedOperators` to propagate through my facets so i figure this must have been a typo since it fixes that issue and doesn't seem to make sense as it was.
